### PR TITLE
Allows guilds and shards to be used in place of colors

### DIFF
--- a/mtglib/constants.py
+++ b/mtglib/constants.py
@@ -9,6 +9,24 @@ TYPES = set(['artifact', 'basic', 'creature', 'enchantment', 'instant', 'land',
 
 COLORS = {'w': 'W', 'u': 'U', 'b': 'B', 'r': 'R', 'g': 'G', 'c': 'C'}
 
+COLOR_PROPER_NAMES = {
+    'boros': 'rw',
+    'golgari': 'bg',
+    'selesnya': 'wg',
+    'dimir': 'ub',
+    'orzhov': 'wb',
+    'izzet': 'ur',
+    'gruul': 'rg',
+    'azorius': 'uw',
+    'rakdos': 'br',
+    'simic': 'ug',
+    'bant': 'wug',
+    'esper': 'ubw',
+    'grixis': 'bru',
+    'jund': 'rbg',
+    'naya': 'wrg'
+}
+
 RARITY_PATTERN = r'(.*?) ((Unc|C)ommon|(Mythic )?Rare|Special|Promo|Land)$'
 
 RARITIES = {

--- a/mtglib/gatherer_request.py
+++ b/mtglib/gatherer_request.py
@@ -2,7 +2,7 @@
 import re
 from collections import Iterable
 
-from mtglib.constants import base_url, TYPES, VALID_WORDS
+from mtglib.constants import base_url, TYPES, VALID_WORDS, COLOR_PROPER_NAMES
 from mtglib.functions import is_string
 
 __all__ = ['SearchRequest', 'CardRequest']
@@ -173,12 +173,19 @@ class ConditionParser(object):
             self.lexers[text_type] = Lexer(rules)
         return self.lexers.get(text_type)
 
+    def preprocess_color(self, value):
+        if COLOR_PROPER_NAMES.get(value.lower(), False):
+            return COLOR_PROPER_NAMES.get(value.lower(), False)
+        return value
+
+
     def get_conditions(self):
         conditions = {}
         for name, value in self.data.items():
             if not is_string(value):
                 continue
             if name == 'color':
+                value = self.preprocess_color(value)
                 self.lexer = self.getlexer('single_character')
             else:
                 self.lexer = self.getlexer('freeform')

--- a/tests/test_gatherer_request.py
+++ b/tests/test_gatherer_request.py
@@ -122,6 +122,19 @@ class WhenParsingColors(unittest.TestCase):
         cond = parser.get_conditions()
         self.assertEqual(cond['color'].keywords, [SearchKeyword('B', 'not'),
                                                   SearchKeyword('R', 'and')])
+                                                  
+    def should_convert_guild_to_colors(self):
+        parser = ConditionParser({'color': 'dimir'})
+        cond = parser.get_conditions()
+        self.assertEqual(cond['color'].keywords, [SearchKeyword('U', 'and'),
+                                                  SearchKeyword('B', 'and')])
+
+    def should_convert_shard_to_colors(self):
+        parser = ConditionParser({'color': 'grixis'})
+        cond = parser.get_conditions()
+        self.assertEqual(cond['color'].keywords, [SearchKeyword('B', 'and'),
+                                                  SearchKeyword('R', 'and'),
+                                                  SearchKeyword('U', 'and')])
 
     def should_raise_error_for_non_color_input(self):
         parser = ConditionParser({'color': 'd'})


### PR DESCRIPTION
Allows guilds and shards to be used in place of color sequences for the --color option. --color=grixis is the same as --color=ubr.

> mtg --color=bant angel

---

Empyrial Archangel 4GWWU
Creature — Angel
Text: (5/8) Flying ; Shroud ; All damage that would be dealt to you is
dealt to Empyrial Archangel instead.
Shards of Alara (Mythic Rare)

---

Maelstrom Archangel WUBRG
Creature — Angel
Text: (5/5) Flying ; Whenever Maelstrom Archangel deals combat damage
to a player, you may cast a nonland card from your hand without paying
its mana cost.
Conflux (Mythic Rare)

---

Stoic Angel 1GWU
Creature — Angel
Text: (3/4) Flying, vigilance ; Players can't untap more than one
creature during their untap steps.
Shards of Alara (Rare)

3 results found.
