### PR TITLE
Special is now automatically set to true when a special card type is searched

### DIFF
--- a/mtglib/constants.py
+++ b/mtglib/constants.py
@@ -24,6 +24,14 @@ TYPES = set([
     'world',
 ])
 
+# Types that require "special = True" to show any cards
+SPECIAL_TYPES = set([
+    'conspiracy',
+    'phenomenon',
+    'plane',
+    'scheme',
+])
+
 COLORS = {'w': 'W', 'u': 'U', 'b': 'B', 'r': 'R', 'g': 'G', 'c': 'C'}
 
 COLOR_PROPER_NAMES = {

--- a/mtglib/gatherer_request.py
+++ b/mtglib/gatherer_request.py
@@ -2,7 +2,7 @@
 import re
 from collections import Iterable
 
-from mtglib.constants import base_url, TYPES, VALID_WORDS, COLOR_PROPER_NAMES
+from mtglib.constants import base_url, TYPES, SPECIAL_TYPES, VALID_WORDS, COLOR_PROPER_NAMES
 from mtglib.functions import is_string
 
 __all__ = ['SearchRequest', 'CardRequest']
@@ -265,6 +265,12 @@ class SearchRequest(object):
             exclude = 'type' in self.exclude_others
             type_words = [w for w in keywords if w.term.lower() in TYPES]
             subtype_words = [w for w in keywords if w.term.lower() not in TYPES]
+
+            # If one of our types is in SPECIAL_TYPES, override the special setting
+            for type_word in type_words:
+                if type_word.term.lower() in SPECIAL_TYPES:
+                    self.special = True
+                    break
 
             del conditions['type']
             if type_words:


### PR DESCRIPTION
I had some free time, and so I figured I'd work on a patch to resolve #16.

I added a SPECIAL_TYPES array to constants.py which contains the types that require special = True for gatherer to show card results. I then added a little check in get_filters() after the types array is created to check if the user asked for any special types, and if so, to set special = True.

I did verify `mtg --type phenomenon` now actually lists phenomena cards, so I believe this works.
