### PR TITLE
Add MANIFEST file to include README, LICENSE.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE


### PR DESCRIPTION
At the moment the archives on PyPI don't actually contain any documentation or the LICENSE file. This commit adds a MANIFEST.in to the root of the repository to tell distutils/setuptools to include README.md and LICENSE explicitly.