### PR TITLE
Import ABC from collections.abc instead of collections for Python 3 compatibility

### DIFF
--- a/mtglib/gatherer_request.py
+++ b/mtglib/gatherer_request.py
@@ -1,6 +1,9 @@
 """Request to the Gatherer site"""
 import re
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from mtglib.constants import base_url, TYPES, SPECIAL_TYPES, VALID_WORDS, COLOR_PROPER_NAMES
 from mtglib.functions import is_string


### PR DESCRIPTION
Fixes #28 